### PR TITLE
initial release

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*   @innovationnorway/terraform

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,0 +1,19 @@
+workflow "Terraform" {
+  on = "push"
+  resolves = ["terraform-fmt"]
+}
+
+action "terraform-fmt" {
+  uses = "innovationnorway/terraform-action@master"
+  args = ["fmt", "-check", "-list", "-recursive"]
+}
+
+workflow "Release" {
+  on = "push"
+  resolves = ["semantic-release"]
+}
+
+action "semantic-release" {
+  uses = "innovationnorway/semantic-release-action@beta"
+  secrets = ["GH_TOKEN"]
+}

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -1,0 +1,1 @@
+extends: "@innovationnorway/semantic-release-terraform-config"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,59 @@
+# Azure AD Application
+
+Create Azure AD Application.
+
+## Example Usage
+
+```hcl
+module "application" {
+  source = "innovationnorway/application/azuread"
+
+  name = "example"
+
+  group_membership_claims = "All"
+
+  api_permissions = [
+    {
+      name = "Microsoft Graph"
+      oauth2_permissions = [
+        "Directory.Read.All",
+        "User.Read"
+      ]
+      app_roles = [
+        "Directory.Read.All"
+      ]
+    }
+  ]
+}
+```
+
+## Arguments
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `name` | `string` | The display name of the application. |
+| `homepage` | `string` | The URL of the application's homepage. |
+| `identifier_uris` | `list` | List of unique URIs that Azure AD can use for the application. |
+| `reply_urls` | `list` | List of URIs to which Azure AD will redirect in response to an OAuth 2.0 request. |
+| `available_to_other_tenants` | `bool` | Whether the application can be used from any Azure AD tenants. Default: `false`. |
+| `native` | `bool` | Whether the application can be installed on a user's device or computer (aka public client). Default: `false`. |
+| `oauth2_allow_implicit_flow` | `bool` | Whether to allow implicit grant flow for OAuth2. Default: `false`. |
+| `group_membership_claims` | `string` | Configures the groups claim issued in a user or OAuth 2.0 access token that the app expects. The options are: `None`, `SecurityGroup` and `All`. Default: `SecurityGroup`. |
+| `api_permissions` | `list` | List of API permissions. |
+| `app_roles` | `list` | List of App roles. |
+
+The `api_permissions` object accepts the following keys:
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `name` | `string` | Name of the API. |
+| `oauth2_permissions` | `list` | List of OAuth2 permissions (scopes). |
+| `app_roles` | `list` | List of App roles. |
+
+The `app_roles` object must have the following keys:
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `name` | `string` | Name of the the App role. |
+| `description` | `string` | Description of the App role. |
+| `member_types` | `list` | List of allowed member types. The options are: `User`, `Application`. |

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,45 @@
+data "azuread_service_principal" "main" {
+  count        = length(local.api_names)
+  display_name = local.api_names[count.index]
+}
+
+resource "azuread_application" "main" {
+  name                       = var.name
+  homepage                   = coalesce(var.homepage, local.homepage)
+  identifier_uris            = local.identifier_uris
+  reply_urls                 = var.reply_urls
+  available_to_other_tenants = var.available_to_other_tenants
+  public_client              = local.public_client
+  oauth2_allow_implicit_flow = var.oauth2_allow_implicit_flow
+  group_membership_claims    = var.group_membership_claims
+  type                       = local.type
+
+  dynamic "required_resource_access" {
+    for_each = local.required_resource_access
+
+    content {
+      resource_app_id = required_resource_access.value.resource_app_id
+
+      dynamic "resource_access" {
+        for_each = required_resource_access.value.resource_access
+
+        content {
+          id   = resource_access.value.id
+          type = resource_access.value.type
+        }
+      }
+    }
+  }
+
+  dynamic "app_role" {
+    for_each = local.app_roles
+
+    content {
+      allowed_member_types = app_role.value.member_types
+      display_name         = app_role.value.name
+      description          = app_role.value.description
+      value                = coalesce(app_role.value.value, app_role.value.name)
+      is_enabled           = app_role.value.enabled
+    }
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,27 @@
+output "name" {
+  value       = azuread_application.main.name
+  description = "The display name of the application."
+}
+
+output "application_id" {
+  value       = azuread_application.main.application_id
+  description = "The ID of the application."
+}
+
+output "object_id" {
+  value       = azuread_application.main.object_id
+  description = "The object ID of the application."
+}
+
+output "app_roles" {
+  value = {
+    for r in azuread_application.main.app_role :
+    r.display_name => {
+      id          = r.id
+      name        = r.display_name
+      value       = r.value
+      description = r.description
+      enabled     = r.is_enabled
+    }
+  }
+}

--- a/test/main.tf
+++ b/test/main.tf
@@ -1,0 +1,54 @@
+resource "random_id" "test" {
+  byte_length = 4
+}
+
+module "application" {
+  source = "../"
+
+  name = format("test-%s", random_id.test.hex)
+
+  group_membership_claims = "All"
+
+  api_permissions = [
+    {
+      name = "Microsoft Graph"
+      oauth2_permissions = [
+        "Directory.Read.All",
+        "User.Read"
+      ]
+      app_roles = [
+        "Directory.Read.All"
+      ]
+    }
+  ]
+
+  app_roles = [
+    {
+      name        = "test"
+      description = "test"
+      member_types = [
+        "Application"
+      ]
+    }
+  ]
+}
+
+data "azuread_application" "test" {
+  name = module.application.name
+}
+
+module "test_assertions" {
+  source = "innovationnorway/assertions/test"
+  equals = [
+    {
+      name = "has identifier URIs"
+      got  = length(data.azuread_application.test.identifier_uris)
+      want = 1
+    },
+    {
+      name = "has role claim"
+      got  = data.azuread_application.test.app_roles.0.value
+      want = "test"
+    }
+  ]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,116 @@
+variable "name" {
+  type        = string
+  description = "The display name of the application"
+}
+
+variable "homepage" {
+  type        = string
+  default     = ""
+  description = "The URL of the application's homepage."
+}
+
+variable "identifier_uris" {
+  type        = list(string)
+  default     = []
+  description = "List of unique URIs that Azure AD can use for the application."
+}
+
+variable "reply_urls" {
+  type        = list(string)
+  default     = []
+  description = "List of URIs to which Azure AD will redirect in response to an OAuth 2.0 request."
+}
+
+variable "available_to_other_tenants" {
+  type        = bool
+  default     = false
+  description = "Whether the application can be used from any Azure AD tenants."
+}
+
+variable "oauth2_allow_implicit_flow" {
+  type        = bool
+  default     = false
+  description = "Whether to allow implicit grant flow for OAuth2."
+}
+
+variable "native" {
+  type        = bool
+  default     = false
+  description = "Whether the application can be installed on a user's device or computer."
+}
+
+variable "group_membership_claims" {
+  type        = string
+  default     = "SecurityGroup"
+  description = "Configures the groups claim issued in a user or OAuth 2.0 access token that the app expects."
+}
+
+variable "api_permissions" {
+  type        = any
+  default     = []
+  description = "List of API permissions."
+}
+
+variable "app_roles" {
+  type        = any
+  default     = []
+  description = "List of App roles."
+}
+
+locals {
+  homepage = format("https://%s", var.name)
+
+  type = var.native ? "native" : "webapp/api"
+
+  public_client = var.native ? true : false
+
+  default_identifier_uris = [format("http://%s", var.name)]
+
+  identifier_uris = var.native ? [] : coalescelist(local.default_identifier_uris, var.identifier_uris)
+
+  api_permissions = [
+    for p in var.api_permissions : merge({
+      id                 = ""
+      name               = ""
+      app_roles          = []
+      oauth2_permissions = []
+    }, p)
+  ]
+
+  api_names = local.api_permissions[*].name
+
+  service_principals = {
+    for s in data.azuread_service_principal.main : s.display_name => {
+      application_id     = s.application_id
+      display_name       = s.display_name
+      app_roles          = { for p in s.app_roles : p.value => p.id }
+      oauth2_permissions = { for p in s.oauth2_permissions : p.value => p.id }
+    }
+  }
+
+  required_resource_access = [
+    for a in local.api_permissions : {
+      resource_app_id = local.service_principals[a.name].application_id
+      resource_access = concat(
+        [for p in a.oauth2_permissions : {
+          id   = local.service_principals[a.name].oauth2_permissions[p]
+          type = "Scope"
+        }],
+        [for p in a.app_roles : {
+          id   = local.service_principals[a.name].app_roles[p]
+          type = "Role"
+        }]
+      )
+    }
+  ]
+
+  app_roles = [
+    for r in var.app_roles : merge({
+      name         = ""
+      description  = ""
+      member_types = []
+      enabled      = true
+      value        = ""
+    }, r)
+  ]
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,7 @@
+
+terraform {
+  required_version = ">= 0.12"
+  required_providers {
+    azuread = ">= 0.5"
+  }
+}


### PR DESCRIPTION
**Note 1:** Requires next version (`0.5.0`) of the AzureAD provider which is not yet available in a stable release.
**Note 2:** Support for exposing APIs will be added later as we first need to add native support for it in the provider.